### PR TITLE
Yield matched locale to block

### DIFF
--- a/lib/roda/plugins/i18n.rb
+++ b/lib/roda/plugins/i18n.rb
@@ -298,7 +298,7 @@ class Roda
             loc = l || Roda.opts[:locale]
             session[:locale] = loc unless session[:locale]
             ::R18n.set(loc)
-            yield if block_given?
+            yield loc if block_given?
             return # NB!! needed to enable routes below to work
           end
         end


### PR DESCRIPTION
Yield the matched locale to the block, similar to a normal Roda route.
