### PR TITLE
Don't set session

### DIFF
--- a/lib/roda/plugins/i18n.rb
+++ b/lib/roda/plugins/i18n.rb
@@ -296,7 +296,6 @@ class Roda
         def locale(opts = {}, &blk)
           on(_match_available_locales_only, opts) do |l|
             loc = l || Roda.opts[:locale]
-            session[:locale] = loc unless session[:locale]
             ::R18n.set(loc)
             yield if block_given?
             return # NB!! needed to enable routes below to work


### PR DESCRIPTION
I think setting the session should be done by the user inside the yielded block, using the value yielded from the match in #4, if they want that value to be set in the first place.

```ruby
r.locale do |locale|
  session[:locale] ||= locale
end
```
If we assume that a session exists, this plugin can't be used where there is no session - ie. a Roda app that performs mailing only.

```ruby
class Mailer < Roda
  plugin :mailer
  plugin :i18n

  route do |r|
    r.locale do  
      r.mail "/some-path" {}
    end
  end
end

Mailer.sendmail("/en/some-path")  # FAILS! No Rack::Session available
```

This is likely a breaking change for anybody relying on this functionality.