### PR TITLE
Cast potentially matched locale to string

### DIFF
--- a/lib/roda/plugins/i18n.rb
+++ b/lib/roda/plugins/i18n.rb
@@ -272,7 +272,7 @@ class Roda
         # This custom matcher allows us to have other routes below the r.locale .. declaration
         def _match_available_locales_only
          lambda do
-           locale = remaining_path.split("/").reject(&:empty?).first
+           locale = remaining_path.split("/").reject(&:empty?).first.to_s
            if ::R18n.available_locales.map(&:code).map(&:downcase).include?(locale.downcase)
              @captures.push(locale)
              @remaining_path = remaining_path.sub("/#{locale}", "")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,7 +166,6 @@ class Minitest::Spec
     app(:bare) do
       plugin :i18n, confs
       route do |r|
-        r.root      { erb('<%= t.one %>') }
         r.is('one') { erb('<%= t.one %>') }
         r.locale do
           r.is('t') { erb('<%= t.one %>') }
@@ -174,6 +173,7 @@ class Minitest::Spec
         end
         # routes behind the block does not work
         r.get('two')   { erb('<%= t.two %>') }
+        r.root      { erb('<%= t.one %>') }
       end
     end
   end


### PR DESCRIPTION
Without this cast, a root block below the locale block will never be reached due to an exception of calling `downcase` on `nil`.

I didn't add a new spec as moving the `r.root` call to the bottom of the block was enough to trigger the failure.

