### PR TITLE
Housekeeping / Preparing next release

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,0 @@
-ruby 3.3.5
-# ruby jruby-9.4.8.0
-just 1.35.0
-java temurin-22.0.2+9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## next (unreleased)
 
 * your changes here
+
+## 0.6.0 (2024-09-24)
+
+* Merge pull request #6 from simonneutert/gh-ci-workflow - Adds a working GitHub CI workflow, reaches a sane/high coverage level
  
-## 0.5.0 (unreleased)
+## 0.5.0 (2024-09-24)
 
 * Merge pull request #5 from simonneutert/bump-dependencies - Add/Bump dependencies, minimum Ruby version to 3.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    roda-i18n (0.6.0)
+    roda-i18n (0.6.1)
       date
       r18n-core (~> 5)
       roda (~> 3.8)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roda-i18n
 
-[![Gem Version](https://badge.fury.io/rb/roda-i18n.svg)](https://badge.fury.io/rb/roda-i18n) [![Ruby](https://github.com/kematzy/roda-i18n/actions/workflows/ruby.yml/badge.svg)](https://github.com/kematzy/roda-i18n/actions/workflows/ruby.yml)
+[![Gem Version](https://badge.fury.io/rb/roda-i18n.svg)](https://badge.fury.io/rb/roda-i18n) [![Ruby](https://github.com/kematzy/roda-i18n/actions/workflows/ruby.yml/badge.svg?branch=master)](https://github.com/kematzy/roda-i18n/actions/workflows/ruby.yml)
 
 
 Add Internationalisation (i18n) and localisation support to your [Roda](http://roda.jeremyevans.net/) apps, based upon the [R18n](https://github.com/ai/r18n) gem.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,23 @@
 # RubyGems Release Process
 
+This document describes the process to release a new version of the RubyGem.
+
+## Before a release
+
 1. Update/Check the version number in the gemspec file.
-2. Check the [CHANGELOG](CHANGELOG.md) for all contributions since the last release.
+2. Check the [CHANGELOG](CHANGELOG.md) for all contributions since the last release. 
+   * Do we need to address any breaking changes?
 3. Update the [README](README.md) in case of any changes.
-4. Run `bundle install` to update the Gemfile.lock file.
-5. Run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+4. Run `bundle install` one last time to update the Gemfile.lock file, in case something was off (trust me, this will one day save the day).
+
+## Release
+
+1. Run `bundle exec rake release` to automagically create a git tag for the version and push the `gem` to [rubygems.org](https://rubygems.org).
+
+## After a succesful release on RubyGems
+
+1. Update the version number in the gemspec file to the next version.
+2. Update the [CHANGELOG](CHANGELOG.md) with a new `next` section.
+3. Run `bundle install` to update the Gemfile.lock file.
+4. Commit the changes and push to the `default branch` repository.
+

--- a/lib/roda/i18n/version.rb
+++ b/lib/roda/i18n/version.rb
@@ -2,6 +2,6 @@
 
 class Roda
   module I18n
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end


### PR DESCRIPTION
After releasing v0.5.0 and v0.6.0 the repo receives the code needed to be prepared for future development.

- [x] update CHANGELOG.md
- [x] update the status badge in the readme for ci status of the tests 
- [x] version bump (with `bundle install`) to v0.6.1
- [x] removes `.tool-versions` from being tracked in git
- [x] update RELEASING.md