### PR TITLE
Update i18n.rb

### DIFF
--- a/lib/roda/plugins/i18n.rb
+++ b/lib/roda/plugins/i18n.rb
@@ -269,7 +269,7 @@ class Roda
         def _match_available_locales_only
           lambda do
             locale = remaining_path.split('/').reject(&:empty?).first.to_s
-            if ::R18n.available_locales.map { |locale| locale.code.downcase }.include?(locale.downcase)
+            if ::R18n.available_locales.map { |available_locale| available_locale.code.downcase }.include?(locale.downcase)
               @captures.push(locale)
               @remaining_path = remaining_path.sub("/#{locale}", '')
             end

--- a/lib/roda/plugins/i18n.rb
+++ b/lib/roda/plugins/i18n.rb
@@ -269,7 +269,7 @@ class Roda
         def _match_available_locales_only
           lambda do
             locale = remaining_path.split('/').reject(&:empty?).first.to_s
-            if ::R18n.available_locales.map { |available_locale| available_locale.code.downcase }.include?(locale.downcase)
+            if ::R18n.available_locales.map { |available_loc| available_loc.code.downcase }.include?(locale.downcase)
               @captures.push(locale)
               @remaining_path = remaining_path.sub("/#{locale}", '')
             end


### PR DESCRIPTION
This pull request includes a small change to the `lib/roda/plugins/i18n.rb` file. The change involves renaming a variable within the `_match_available_locales_only` method to improve code clarity.

And rubocop was unhappy about var shadowing. 

* [`lib/roda/plugins/i18n.rb`](diffhunk://#diff-315036f498297c7c181924c1c5632046396472dc99d46fed55cd0153f8076b6aL272-R272): Renamed the variable `locale` to `available_loc` within the `map` method to avoid confusion with the outer `locale` variable.