### PR TITLE
r18n-core was bumped to v6 recently 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "jruby-9.4", "jruby-10.0"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 3
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ["3.2", "3.3", "3.4", "4.0", "jruby-9.4", "jruby-10.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "jruby-10.0"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 3
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-rake
   - rubocop-performance
   - rubocop-minitest
@@ -17,7 +17,7 @@ require:
 # See https://docs.rubocop.org/rubocop/configuration
 
 AllCops:
-    TargetRubyVersion: "3.0"
+    TargetRubyVersion: "3.2"
     NewCops: enable
 
 Layout/LineLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## next (unreleased)
 
-* your changes here
+* Multiple updates to dependencies in preparation for a new release.
+* Upgraded r18n-core to v6 and up, which fixed a couple of issues with the prior version, and also dropped support for Ruby below 3.2 - which we followed suit on by updating our minimum Ruby version to 3.2.0.
+* JRuby support for 9.4 was dropped from CI.
+* Ruby 4.0 support was added. 
+
+  * __Breaking Changes:__
+  * minimum Ruby version is now >= 3.2.0
+  * minimum JRuby version is now >= 10.0.0
 
 ## 0.6.0 (2024-09-24)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     roda-i18n (0.6.1)
       date
-      r18n-core (~> 5)
+      r18n-core (~> 6)
       roda (~> 3.8)
       tilt
 
@@ -41,7 +41,8 @@ GEM
       racc
     prism (1.9.0)
     public_suffix (6.0.2)
-    r18n-core (5.0.1)
+    r18n-core (6.0.0)
+      bigdecimal (~> 4.0)
     racc (1.8.1)
     racc (1.8.1-java)
     rack (3.2.5)
@@ -121,4 +122,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.5.18
+  2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     lint_roller (1.1.0)
     mcp (0.8.0)
       json-schema (>= 4.1)
-    minitest (5.26.1)
+    minitest (5.27.0)
     minitest-hooks (1.5.3)
       minitest (> 5.3)
     minitest-rg (5.4.0)
@@ -40,7 +40,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     r18n-core (6.0.0)
       bigdecimal (~> 4.0)
     racc (1.8.1)
@@ -85,7 +85,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.1)
+    simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     tilt (2.7.0)
     unicode-display_width (3.2.0)
@@ -122,4 +122,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-  2.7.2
+   2.7.2

--- a/roda-i18n.gemspec
+++ b/roda-i18n.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |spec|
   spec.rdoc_options += ['--quiet', '--line-numbers', '--inline-source', '--title',
                         'Roda-i18n: internationalisation plugin', '--main', 'README.md']
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.add_dependency 'date'
-  spec.add_dependency 'r18n-core', '~> 5'
+  spec.add_dependency 'r18n-core', '~> 6'
   spec.add_dependency 'roda', '~> 3.8'
   spec.add_dependency 'tilt'
 

--- a/spec/roda/i18n_spec.rb
+++ b/spec/roda/i18n_spec.rb
@@ -730,7 +730,7 @@ class Rodai18nTests < Minitest::Spec
               _(o).must_match(/\["de", "Deutsch"\]/)
               _(o).must_match(/\["en", "English"\]/)
               _(o).must_match(/\["es", "Español"\]/)
-              _(o).must_match(/\["sv-SE", "Svenska"\]/)
+              _(o).must_match(/\["sv-SE", "Svenska \(Sverige\)"\]/)
             end
           end
 

--- a/spec/roda/i18n_spec.rb
+++ b/spec/roda/i18n_spec.rb
@@ -562,7 +562,7 @@ class Rodai18nTests < Minitest::Spec
                 _(i18n_app('<%= l Date.parse("October 5, 2011"), :full %>', {}, @es_opts))
                   .must_equal '05 de Octubre de 2011'
                 _(i18n_app('<%= l Date.parse("October 5, 2011"), :full %>', {}, @sv_opts))
-                  .must_equal '5 oktober 2011 2011' # TODO: fix this bug in R18n
+                  .must_equal '5 oktober 2011'
               end
             end
           end
@@ -708,11 +708,6 @@ class Rodai18nTests < Minitest::Spec
                 it 'should NOT support translation from :locale "es"' do
                   _(i18n_app('<%= t.do.you.speak.spanish %>', {}, @conf))
                     .must_equal 'do.you.speak.<span style="color: red">[spanish]</span>'
-                end
-
-                it 'should still support translation from :locale "en" somehow??' do
-                  _(i18n_app('<%= t.do.you.speak.english %>', {}, @conf))
-                    .must_equal 'Do you speak English?'
                 end
               end
             end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ module Minitest
       s
     end
 
-    def _app(&block)
+    def _app(&)
       c = Class.new(Roda)
       c.plugin :render
       c.plugin(:not_found) { raise "path #{request.path_info} not found" }
@@ -80,7 +80,7 @@ module Minitest
           render(opts.merge(inline: str))
         end
       end
-      c.class_eval(&block)
+      c.class_eval(&)
       c
     end
 


### PR DESCRIPTION
Hey there,

[r18n-core](https://github.com/r18n/r18n-core/commit/b4c43618a68334b61e055e0ba62879108a507624) was bumped to v6 recently.

I will run the from my fork in prod for a couple of days, then merge if all is fine (which I expect). Then reflect the choices made in r18n-core in the PR regarding the Ruby requirements. 

Here's a shortened copy of the changes listed:

> * Drop Ruby 2.5, 2.6, 2.7, 3.0 and 3.1 support.
> * Add Ruby 3.2, 3.3, 3.4 and 4.0 support.
> * Add `bigdecimal` runtime dependency.
> * Update development dependencies.
> * Resolve new RuboCop offenses.
> * Improve CI config.
> 

Maybe we release a new, fresh gem after this, too? It's been a while :hugs: 

Cheers